### PR TITLE
docs: update REAME with docker compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ docker run --rm -p 3000:3000 \
   service-atlas-frontend
 ```
 
+### Using Docker Compose
+
+1. Clone the repository
+2. Update .env file
+   ```
+   # 'neo4j' not 'localhost' because in docker-compose we use the service name "neo4j" to connect to the database container.
+   DB_URL=neo4j://neo4j:7687 
+   DB_USERNAME=neo4j
+   DB_PASSWORD=1234%qwerT
+   ```
+3. Run
+   ```sh
+   docker-compose up -d
+   ```
+4. Open http://localhost:3000
+
 Notes:
 - The app listens on port 3000 in the container.
 - `NUXT_PUBLIC_API_URL` overrides `runtimeConfig.public.apiUrl` at runtime and is recommended for containers.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ docker run --rm -p 3000:3000 \
 
 1. Clone the repository
 2. Update .env file
-   ```
+   ```env
    # 'neo4j' not 'localhost' because in docker-compose we use the service name "neo4j" to connect to the database container.
    DB_URL=neo4j://neo4j:7687 
    DB_USERNAME=neo4j


### PR DESCRIPTION
In order to facilitate the first and thus the possible adoption of Atlas, a brief session was added with details on how to run the app locally using docker-compose.

After facing a few hickupt I'd like to clear that out for future users

## Description

<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Using Docker Compose" section to the README with step-by-step instructions for setting up and running the application using Docker Compose.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/service-atlas/frontend/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #

## Post Deployment Tasks?
